### PR TITLE
Fix compile errors on M1 

### DIFF
--- a/src/vendor/backward.hpp
+++ b/src/vendor/backward.hpp
@@ -3935,7 +3935,11 @@ public:
 #elif defined(__arm__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)
-    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
+    #if defined(__APPLE__)
+      error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__pc);
+    #else
+      error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
+    #endif
 #elif defined(__mips__)
     error_addr = reinterpret_cast<void *>(reinterpret_cast<struct sigcontext*>(&uctx->uc_mcontext)->sc_pc);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) ||        \


### PR DESCRIPTION
There are compile errors on Apple M1 machines, see
https://github.com/ignitionrobotics/ign-gazebo/issues/1362#issuecomment-1118952775

To fix the build, I ported the changes from upstream backward repo::
https://github.com/bombela/backward-cpp/blob/master/backward.hpp#L4220-L4225

The alternative is to update the `backward.hpp` file with the latest version from upstream, which I tried that and noticed quite a few changes between our copy and the latest version. So I took the safest route and just applied minimal changes to fix the build.