### PR TITLE
Adds ability to get a file from a running Gazebo instance

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -286,26 +286,28 @@ int rootCallback(struct lws *_wsi,
 
     // Handle incoming messages
     case LWS_CALLBACK_RECEIVE:
-      igndbg << "LWS_CALLBACK_RECEIVE\n";
-
-      // Prevent too many connections.
-      if (self->maxConnections >= 0 &&
-          self->connections.size()+1 > self->maxConnections)
       {
-        ignerr << "Skipping new connection, limit of "
-          << self->maxConnections << " has been reached\n";
+        igndbg << "LWS_CALLBACK_RECEIVE\n";
 
-        // This will return an error code of 1008 with a reason of
-        // "max_connections".
-        std::string reason = "max_connections";
-        lws_close_reason(_wsi, LWS_CLOSE_STATUS_POLICY_VIOLATION,
-          reinterpret_cast<unsigned char *>(reason.data()), reason.size());
+        // Prevent too many connections.
+        if (self->maxConnections >= 0 &&
+            self->connections.size()+1 > self->maxConnections)
+        {
+          ignerr << "Skipping new connection, limit of "
+            << self->maxConnections << " has been reached\n";
 
-        // Return non-zero to close the connection.
-        return -1;
+          // This will return an error code of 1008 with a reason of
+          // "max_connections".
+          std::string reason = "max_connections";
+          lws_close_reason(_wsi, LWS_CLOSE_STATUS_POLICY_VIOLATION,
+            reinterpret_cast<unsigned char *>(reason.data()), reason.size());
+
+          // Return non-zero to close the connection.
+          return -1;
+        }
+        self->OnMessage(fd, std::string((const char *)_in).substr(0, _len));
+        break;
       }
-      self->OnMessage(fd, std::string((const char *)_in));
-      break;
 
     default:
       // Do nothing on default.
@@ -659,7 +661,7 @@ void WebsocketServer::OnDisconnect(int _socketId)
 }
 
 //////////////////////////////////////////////////
-void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
+void WebsocketServer::OnMessage(int _socketId, const std::string _msg)
 {
   // Skip invalid sockets
   if (this->connections.find(_socketId) == this->connections.end())
@@ -673,7 +675,7 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
       // Count the number of commas to handle a frame like "sub,,,"
       std::count(_msg.begin(), _msg.end(), ',') != 3)
   {
-    ignerr << "Received an invalid frame with " << frameParts.size()
+    ignerr << "Received an invalid frame[" << _msg << "] with " << frameParts.size()
       << "components when 4 is expected.\n";
     return;
   }
@@ -990,6 +992,52 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
         ignwarn << "Unable to set topic rate for topic[" << topic
                 << "]" << std::endl;
       }
+    }
+  }
+  else if (frameParts[0] == "asset")
+  {
+    std::string assetUri = frameParts[1];
+
+    std::string resolvedPath;
+
+    // Short circuit the case where the assetURI is already a valid path.
+    if (common::exists(assetUri))
+    {
+      resolvedPath = assetUri;
+    }
+    else
+    {
+      ignition::msgs::StringMsg req, rep;
+      req.set_data(assetUri);
+      bool result;
+      unsigned int timeout = 2000;
+
+      // Request the file path from Gazebo
+      bool executed = this->node.Request("/gazebo/resource_paths/resolve",
+          req, timeout, rep, result);
+      if (executed && result)
+        resolvedPath = rep.data();
+    }
+
+    if (!resolvedPath.empty())
+    {
+      // Read the file
+      std::ifstream infile(resolvedPath, std::ios_base::binary);
+      std::string fileBuffer = std::string(
+          std::istreambuf_iterator<char>(infile),
+          std::istreambuf_iterator<char>());
+
+      // Store the file in a protobuf message
+      ignition::msgs::Bytes bytes;
+      bytes.set_data(fileBuffer);
+
+      // Construct the response message
+      std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
+          std::string("ignition.msgs.Bytes"), bytes.SerializeAsString());
+
+      // Queue the message for delivery.
+      this->QueueMessage(this->connections[_socketId].get(),
+          data.c_str(), data.length());
     }
   }
 }

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -100,6 +100,8 @@ namespace ignition
     ///     6. "particle_emitters": Get the list of particle emitters.
     ///                  definitions.
     ///     7. "unsub": Unsubscribe from the topic in the `topic_name` component
+    ///     8. "asset": Get a file as a byte array from a running Gazebo
+    ///                 server.
     ///
     /// The `topic_name` component is mandatory for the "sub", "pub", and
     /// "unsub" operations. If present, it must be the name of an Ignition
@@ -178,7 +180,7 @@ namespace ignition
       /// \param[in] _socketId ID of the socket.
       public: void OnDisconnect(int _socketId);
 
-      public: void OnMessage(int _socketId, const std::string &_msg);
+      public: void OnMessage(int _socketId, const std::string _msg);
 
       public: void OnRequestMessage(int _socketId, const std::string &_msg);
 
@@ -289,13 +291,16 @@ namespace ignition
 
                  /// \brief Get the protobuf definitions.
                  PROTOS = 3,
+
+                 /// \brief Get an asset as a byte array.
+                 ASSET = 4,
                };
 
       /// \brief The set of valid operations, in string  form. These values
       /// can be sent in websocket message frames.
       /// These valus must align with the `Operation` enum.
       private: std::vector<std::string> operations{
-                 "sub", "pub", "topics", "protos"};
+                 "sub", "pub", "topics", "protos", "asset"};
 
       /// \brief Store publish headers for topics. This is here to improve
       /// performance. Keys are topic names and values are frame headers.


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Meshes, textures, and other files may not be accessible to a websocket client through Fuel or other public URLs. This PR allows a websocket client to request a file from a Gazebo server. The file, if found, is returned as a byte array. It's up to the requester to handle the byte array appropriately.
 
Requires: https://github.com/gazebosim/gz-sim/pull/1508

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.