### PR TITLE
Detect gz program instead of using CMake module to check for gz-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,13 @@ gz_find_package(ignition-plugin2 REQUIRED_BY launch COMPONENTS loader register)
 set(IGN_PLUGIN_MAJOR_VER ${ignition-plugin2_VERSION_MAJOR})
 
 #--------------------------------------
-# Find ignition-tools
-gz_find_package(ignition-tools2
-  REQUIRED
-  PKGCONFIG "ignition-tools")
+# Find if gz command is available
+find_program(GZ_TOOLS_PROGRAM gz)
+if (GZ_TOOLS_PROGRAM)
+  message (STATUS "Searching for gz program - found. CLI tests can be built.")
+else()
+  message (STATUS "Searching for gz program - not found. CLI tests are skipped.")
+endif()
 
 #--------------------------------------
 # Find ignition-transport

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -2,6 +2,11 @@
 # "gtest_sources" variable.
 gz_get_libsources_and_unittests(sources gtest_sources)
 
+# Disable tests that need CLI if gz-tools is not found
+if (MSVC OR NOT GZ_TOOLS_PROGRAM)
+  list(REMOVE_ITEM gtest_sources gz_TEST.cc)
+endif()
+
 add_library(gz STATIC gz.cc)
 target_include_directories(gz PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(gz PUBLIC


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/gazebo-tooling/release-tools/issues/472

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This branch was broken when https://github.com/gazebosim/gz-tools/pull/96 was merged. This PR fixes the build by addressing https://github.com/gazebo-tooling/release-tools/issues/472 like other libraries did.

Sorry for the disruption, I should have built the entire stack with the `gz-tools` PR instead of just a few libs.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
