### PR TITLE
Add pause and stop to Websocket Server

### DIFF
--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -111,11 +111,13 @@ namespace ignition
     ///     13. "sim": Pause, play, or stop the simulation.
     ///
     /// The `topic_name` component is mandatory for the "sub", "pub", and
-    /// "unsub" operations.
-    /// It is also mandatory for the "sim" operation when used with "pause" and
-    /// "play" types. When used with "stop", a default topic will be used if
-    /// none supplied.
-    /// If present, it must be the name of an Ignition Transport topic.
+    /// "unsub" operations. If present, it must be the name of an Ignition
+    /// Transport topic.
+    /// `topic_name` is also mandatory for the "sim" operation when used with
+    /// "pause" and "play" types. It should be the name of a service that takes
+    /// ignition.msgs.WorldControl. When used with "stop" type, it should be
+    /// the name of a service that takes ignition.msgs.ServerControl. A default
+    /// topic "/server_control" will be used if none supplied.
     ///
     /// The `message_type` component is mandatory for the "pub" operation. If
     /// present it names the Ignition Message type, such as

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -103,14 +103,24 @@ namespace ignition
     ///     8. "asset": Get a file as a byte array from a running Gazebo
     ///                 server. Set the payload to the file URI that is
     ///                 being requested.
+    ///     9. "worlds": Get world info.
+    ///     10. "scene": Get scene info.
+    ///     11. "image": Subscribe to an image in the `topic_name` component.
+    ///     12. "throttle": Throttle a topic in the `topic_name` component by
+    ///                 the rate in the `payload` component.
+    ///     13. "sim": Pause, play, or stop the simulation.
     ///
     /// The `topic_name` component is mandatory for the "sub", "pub", and
-    /// "unsub" operations. If present, it must be the name of an Ignition
-    /// Transport topic.
+    /// "unsub" operations.
+    /// It is also mandatory for the "sim" operation when used with "pause" and
+    /// "play" types. When used with "stop", a default topic will be used if
+    /// none supplied.
+    /// If present, it must be the name of an Ignition Transport topic.
     ///
     /// The `message_type` component is mandatory for the "pub" operation. If
     /// present it names the Ignition Message type, such as
-    /// "ignition.msgs.Clock".
+    /// "ignition.msgs.Clock". It is also mandatory for the "sim" operation and
+    /// must be one of "play", "pause", or "stop".
     ///
     /// The `payload` component is mandatory for the "pub" operation. If
     /// present, it contains a serialized string of an Ignition Message.


### PR DESCRIPTION
# 🎉 New feature

Add ability to pause and stop simulation in Websocket Server.

## Summary

This may not be the best scheme:
In operation field, specify `sim`.
In message_type field (might not be the best place), specify `pause` `play` or `stop`.
In topic_name field, specify `/server_control` service for stop, and the WorldControl service for pause and play, which should look like `/world/empty/control`, replacing `empty` with the world name.

If we don't want to put those action words in the message_type field, another alternative might be to specify pause/play/stop in the operation field. Then there wouldn't be a high level `sim` operation, it'd just be 3 separate operations. That seems less organized though.

## Test it

I didn't see any tests for this class, so I guess we have to test it using a web application?
@german-e-mas could you try and let me know your feedback?

Launch a simulation world and the websocket:
```
ign gazebo -v 4 <world.sdf>
ign launch -v 4 ~/ign_fortress/src/ign-launch/examples/websocket.ign
```
Then, send the commands above through the websocket (I'm not sure how to do that on my end).

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.