### PR TITLE
Update gz-sim version required on CMakeLists.txt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,8 @@ gz_find_package (Qt5
 
 #--------------------------------------
 # Find gz-sim
-gz_find_package(gz-sim7 REQUIRED PRIVATE COMPONENTS gui)
-set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
+gz_find_package(gz-sim8 REQUIRED PRIVATE COMPONENTS gui)
+set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 
 gz_pkg_check_modules(websockets libwebsockets)
 if (NOT websockets_FOUND)


### PR DESCRIPTION
FYI: @Crola1702 
Signed-off-by: Crola1702 <j.arroyo@uniandes.edu.co>

Signed-off-by: Crola1702 <j.arroyo@uniandes.edu.co>

# 🦟 Bug fix
This addresses the build regressions happening on gz-launci-win, reference build: 
https://build.osrfoundation.org/job/ign_launch-ci-win/70/

## Summary
This PR just bumps the required version on `gz-sim` as a dependency.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.