### PR TITLE
Fix usage of message headers

### DIFF
--- a/plugins/joy_to_twist/JoyToTwist.cc
+++ b/plugins/joy_to_twist/JoyToTwist.cc
@@ -19,9 +19,10 @@
 #include <sys/stat.h>
 #ifndef _WIN32
   #include <unistd.h>
-#else
-
 #endif
+
+#include <gz/msgs/joy.pb.h>
+#include <gz/msgs/twist.pb.h>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>

--- a/plugins/joy_to_twist/JoyToTwist.hh
+++ b/plugins/joy_to_twist/JoyToTwist.hh
@@ -19,9 +19,11 @@
 
 #include <string>
 #include <thread>
+
+#include <gz/msgs/joy.pb.h>
+
 #include <gz/launch/Plugin.hh>
 #include <gz/math/Vector3.hh>
-#include <gz/msgs.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 
@@ -29,7 +31,7 @@ namespace gz
 {
   namespace launch
   {
-    /// \brief Converts gz::msgs::Joystick messages to
+    /// \brief Converts gz::msgs::Joy messages to
     /// gz::msgs::Twist.
     ///
     /// # Example usage
@@ -38,7 +40,7 @@ namespace gz
     /// <plugin name="gz::launch::JoyToTwist"
     ///         filename=gz-launch-joytotwist0">
     ///   <!-- Incoming topic that publishes
-    ///         gz::msgs::Joystick messages -->
+    ///         gz::msgs::Joy messages -->
     ///   <input_topic>/joy</input_topic>
     ///
     ///   <!-- Outgoing topic that publishes gz::msgs::Twist messages -->

--- a/plugins/joystick/Joystick.cc
+++ b/plugins/joystick/Joystick.cc
@@ -19,10 +19,12 @@
 #include <linux/joystick.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include <gz/msgs/joy.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
 #include <gz/math/Helpers.hh>
-#include <gz/msgs.hh>
 #include <gz/transport/Node.hh>
 
 #include "Joystick.hh"

--- a/plugins/sim_factory/SimFactory.cc
+++ b/plugins/sim_factory/SimFactory.cc
@@ -15,11 +15,13 @@
  *
 */
 
-#include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
 
 #include <gz/common/Util.hh>
 #include <gz/common/Console.hh>
+#include <gz/msgs/Utility.hh>
 #include "SimFactory.hh"
 
 using namespace gz;

--- a/plugins/sim_server/SimServer.cc
+++ b/plugins/sim_server/SimServer.cc
@@ -327,11 +327,16 @@ bool SimServer::Load(const tinyxml2::XMLElement *_elem)
     }
 
     // Create an SDF element of the plugin
+    sdf::Plugin plugin;
+    plugin.SetFilename(file);
+    plugin.SetName(name);
+
     sdf::ElementPtr sdf(new sdf::Element);
     copyElement(sdf, elem);
+    plugin.InsertContent(sdf);
 
     // Add the plugin to the server config
-    serverConfig.AddPlugin({entityName, entityType, file, name, sdf});
+    serverConfig.AddPlugin({entityName, entityType, plugin});
   }
 
   // Set headless rendering

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -16,6 +16,17 @@
 */
 
 #include <algorithm>
+
+#include <gz/msgs/bytes.pb.h>
+#include <gz/msgs/empty.pb.h>
+#include <gz/msgs/image.pb.h>
+#include <gz/msgs/particle_emitter_v.pb.h>
+#include <gz/msgs/publish.pb.h>
+#include <gz/msgs/publishers.pb.h>
+#include <gz/msgs/scene.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/stringmsg_v.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/Image.hh>
 #include <gz/common/Util.hh>


### PR DESCRIPTION
# 🦟 Bug fix

* Related to https://github.com/gazebosim/gz-transport/pull/315

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This is needed to compile since https://github.com/gazebosim/gz-transport/pull/315 was merged.

Also fixed a deprecation warning due to https://github.com/gazebosim/gz-sim/pull/1352.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
