### PR TITLE
Return a message on asset error

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -1007,6 +1007,16 @@ void WebsocketServer::OnAsset(int _socketId,
   if (_frameParts.size() <= 1)
   {
     ignerr << "Asset requested, but asset URI is missing\n";
+
+    ignition::msgs::StringMsg msg;
+    msg.set_data("asset_uri_missing");
+    std::string data = BUILD_MSG(this->operations[ASSET], "",
+        msg.GetTypeName(), msg.SerializeAsString());
+
+    // Queue the message for delivery.
+    this->QueueMessage(this->connections[_socketId].get(),
+        data.c_str(), data.length());
+
     return;
   }
 
@@ -1047,12 +1057,20 @@ void WebsocketServer::OnAsset(int _socketId,
 
     // Construct the response message
     std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
-        std::string("ignition.msgs.Bytes"), bytes.SerializeAsString());
+        bytes.GetTypeName(), bytes.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),
         data.c_str(), data.length());
   }
+
+   ignition::msgs::StringMsg msg;
+   msg.set_data("asset_not_found");
+   std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
+       msg.GetTypeName(), msg.SerializeAsString());
+   // Queue the message for delivery.
+   this->QueueMessage(this->connections[_socketId].get(),
+       data.c_str(), data.length());
 }
 
 //////////////////////////////////////////////////

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -744,7 +744,6 @@ void WebsocketServer::OnMessage(int _socketId, const std::string _msg)
       }
     }
 
-    std::cout << allProtos << std::endl;
     this->QueueMessage(this->connections[_socketId].get(),
         allProtos.c_str(), allProtos.length());
   }

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -744,6 +744,7 @@ void WebsocketServer::OnMessage(int _socketId, const std::string _msg)
       }
     }
 
+    std::cout << allProtos << std::endl;
     this->QueueMessage(this->connections[_socketId].get(),
         allProtos.c_str(), allProtos.length());
   }
@@ -1063,14 +1064,17 @@ void WebsocketServer::OnAsset(int _socketId,
     this->QueueMessage(this->connections[_socketId].get(),
         data.c_str(), data.length());
   }
+  else
+  {
 
-   ignition::msgs::StringMsg msg;
-   msg.set_data("asset_not_found");
-   std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
-       msg.GetTypeName(), msg.SerializeAsString());
-   // Queue the message for delivery.
-   this->QueueMessage(this->connections[_socketId].get(),
-       data.c_str(), data.length());
+    ignition::msgs::StringMsg msg;
+    msg.set_data("asset_not_found");
+    std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
+        msg.GetTypeName(), msg.SerializeAsString());
+    // Queue the message for delivery.
+    this->QueueMessage(this->connections[_socketId].get(),
+        data.c_str(), data.length());
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Returns a string message when an error is encountered during an OnAsset call.

@german-e-mas , can you give this a try?

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.