### PR TITLE
5 to 6 20220921

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,35 @@
 
 ## Gazebo Launch 5.x
 
-### Gazebo Launch 5.X.X (20XX-XX-XX)
+### Gazebo Launch 5.2.0 (2022-08-16)
+
+1. Add code coverage ignore file
+    * [Pull request #179](https://github.com/gazebosim/gz-launch/pull/179)
+
+1. Change `IGN_DESIGNATION` to `GZ_DESIGNATION`
+    * [Pull request #181](https://github.com/gazebosim/gz-launch/pull/181)
+    * [Pull request #182](https://github.com/gazebosim/gz-launch/pull/182)
+
+1. fix `ign_TEST` for Fortress
+    * [Pull request #180](https://github.com/gazebosim/gz-launch/pull/180)
+
+1. Ignition -> Gazebo
+    * [Pull request #178](https://github.com/gazebosim/gz-launch/pull/178)
+
+1. Bash completion for flags
+    * [Pull request #167](https://github.com/gazebosim/gz-launch/pull/167)
+
+1. Adds ability to get a file from a running Gazebo instance
+    * [Pull request #164](https://github.com/gazebosim/gz-launch/pull/164)
+
+1. Add Ubuntu Jammy CI
+    * [Pull request #154](https://github.com/gazebosim/gz-launch/pull/154)
+
+1. Depend on `python3-yaml` instead of `python-yaml`
+    * [Pull request #153](https://github.com/gazebosim/gz-launch/pull/153)
+
+## Gazebo Launch 5.x
+
 
 ### Gazebo Launch 5.1.0 (2022-03-21)
 1. Use exec instead of popen to run gz-launch binary


### PR DESCRIPTION
# ➡️ Forward port

Port ign-launch5 to gz-launch6

I believe the only difference is the Changelog, which should be safe to merge. 

Branch comparison: [https://github.com/gazebosim/<REPO>/compare/<TO_BRANCH>...<FROM_BRANCH>](https://github.com/gazebosim/gz-launch/compare/gz-launch6...ignition-launch5_5.2.0)

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)