### PR TITLE
Update changelog for 6.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,35 @@
 ## Gazebo Launch 6.x
 
-### Gazebo Launch 6.X.X (202X-XX-XX)
+### Gazebo Launch 6.0.0
+
+1. Fix macOs compiler error.
+    * [Pull request #161](https://github.com/gazebosim/gz-launch/pull/161)
+
+1. Update to latest gtest.
+    * [Pull request #174](https://github.com/gazebosim/gz-launch/pull/174)
+
+1. Ignition to Gazebo renaming
+    * [Pull request #162](https://github.com/gazebosim/gz-launch/pull/162)
+    * [Pull request #163](https://github.com/gazebosim/gz-launch/pull/163)
+    * [Pull request #165](https://github.com/gazebosim/gz-launch/pull/165)
+    * [Pull request #166](https://github.com/gazebosim/gz-launch/pull/166)
+    * [Pull request #168](https://github.com/gazebosim/gz-launch/pull/168)
+    * [Pull request #169](https://github.com/gazebosim/gz-launch/pull/169)
+    * [Pull request #170](https://github.com/gazebosim/gz-launch/pull/170)
+    * [Pull request #171](https://github.com/gazebosim/gz-launch/pull/171)
+    * [Pull request #172](https://github.com/gazebosim/gz-launch/pull/172)
+    * [Pull request #173](https://github.com/gazebosim/gz-launch/pull/173)
+    * [Pull request #176](https://github.com/gazebosim/gz-launch/pull/176)
+    * [Pull request #188](https://github.com/gazebosim/gz-launch/pull/188)
+
+1. Fix `msgs` header usage.
+    * [Pull request #196](https://github.com/gazebosim/gz-launch/pull/196)
+
+1. Version bumps and removal of deprecations
+    * [Pull request #144](https://github.com/gazebosim/gz-launch/pull/144)
+    * [Pull request #145](https://github.com/gazebosim/gz-launch/pull/145)
+    * [Pull request #150](https://github.com/gazebosim/gz-launch/pull/150)
+    * [Pull request #156](https://github.com/gazebosim/gz-launch/pull/156)
 
 ## Gazebo Launch 5.x
 


### PR DESCRIPTION
# 🎈 Change log Release

Preparation for 6.0.0 release.

Comparison is broken, probably because I merged incorrectly once. I used [this](https://github.com/gazebosim/gz-launch/pulls?q=is%3Apr+is%3Aclosed+label%3A%22%F0%9F%8C%B1+garden%22).

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.