### PR TITLE
Fix gz_test when using a CMake generator different from make

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -68,7 +68,7 @@ TEST(CmdLine, Ls)
   std::string cmd = "gz launch " + get_config_path("ls.gzlaunch");
   std::string output = customExecStr(cmd);
   EXPECT_TRUE(output.find("CMakeFiles") != std::string::npos) << output;
-  EXPECT_TRUE(output.find("Makefile") != std::string::npos) << output;
+  EXPECT_TRUE(output.find("cmake_install.cmake") != std::string::npos) << output;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

The PR fixes a failure when running test using CMake generators different from `Unix Makefiles`,  such as `ninja` .

## Summary

This fix permits to run the test suite without problems also when using the `ninja` generator.
I am not sure this make the test run for all possible CMake generators (for example, I guess it would fail for Multiple-Config Generators) but anyhow it is a strict improvement.

Without this fix, running the tests with ninja would fail with:
~~~
2022-10-30T19:16:15.7716940Z /Users/runner/mambaforge/conda-bld/gz-launch6_1667156961572/work/src/cmd/gz_TEST.cc:71: Failure
2022-10-30T19:16:15.7818910Z Value of: output.find("Makefile") != std::string::npos
2022-10-30T19:16:15.7920580Z   Actual: false
2022-10-30T19:16:15.8001560Z Expected: true
2022-10-30T19:16:15.8003040Z CMakeFiles
2022-10-30T19:16:15.8017710Z CTestTestfile.cmake
2022-10-30T19:16:15.8018820Z cmake_install.cmake
2022-10-30T19:16:15.8082140Z cmdlaunch6.rb
2022-10-30T19:16:15.8083300Z cmdlaunch6.rb.configured
2022-10-30T19:16:15.8084830Z launch6.bash_completion.sh
2022-10-30T19:16:15.8085850Z launch6.yaml
2022-10-30T19:16:15.8088570Z launch6.yaml.configured
2022-10-30T19:16:15.8089650Z test_cmdlaunch6.rb.configured
~~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
