### PR TITLE
Small cleanup fixes

### DIFF
--- a/include/ignition/launch/Plugin.hh
+++ b/include/ignition/launch/Plugin.hh
@@ -30,6 +30,9 @@ namespace ignition
     /// \brief Base class for launch plugins.
     class Plugin
     {
+      // Default destructor
+      public virtual ~Plugin() {};
+
       /// \brief Load function that each launch plugin must implement.
       /// \param[in] _elem Pointer to the XML for this plugin.
       /// \return True to keep the plugin alive. Return false to have the

--- a/plugins/websocket_server/MessageDefinitions.hh.in
+++ b/plugins/websocket_server/MessageDefinitions.hh.in
@@ -17,6 +17,8 @@
 #ifndef IGNITION_LAUNCH_WEBSOCKETSERVER_MESSAGEDEFINITIONS_HH_
 #define IGNITION_LAUNCH_WEBSOCKETSERVER_MESSAGEDEFINITIONS_HH_
 
+#include <string>
+
 namespace ignition
 {
   namespace launch


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This adds a missing `<string>` header file, and declares `Plugin's` virtual destructor so that a derived class's destructor can be called properly.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
