### PR TITLE
Update gz-launch to use new message generation pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,18 @@ set(GZ_TRANSPORT_VER ${gz-transport13_VERSION_MAJOR})
 gz_find_package(gz-msgs10 REQUIRED)
 set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
 
+# Get the gz-msgs installed messages and generate a library from them
+gz_msgs_get_installed_messages(
+  MESSAGES_PATH_VARIABLE MSGS_PATH
+  MESSAGES_PROTOS_VARIABLE MSGS_PROTOS)
+
+gz_msgs_generate_messages(
+  TARGET gz_msgs_gen
+  PROTO_PACKAGE "gz.msgs"
+  MSGS_PATH ${MSGS_PATH}
+  MSGS_PROTOS ${MSGS_PROTOS})
+
+
 #--------------------------------------
 # Find gz-math
 gz_find_package(gz-math7 REQUIRED)

--- a/plugins/joy_to_twist/CMakeLists.txt
+++ b/plugins/joy_to_twist/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(${plugin}
     gz-math${GZ_MATH_VER}::gz-math${GZ_MATH_VER}
     gz-plugin${GZ_PLUGIN_VER}::core
     gz-transport${GZ_TRANSPORT_VER}::core
+    gz_msgs_gen
 )
 
 install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})

--- a/plugins/joystick/CMakeLists.txt
+++ b/plugins/joystick/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(${plugin}
     gz-math${GZ_MATH_VER}::gz-math${GZ_MATH_VER}
     gz-transport${GZ_TRANSPORT_VER}::core
     gz-plugin${GZ_PLUGIN_VER}::core
+    gz_msgs_gen
 )
 
 install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})

--- a/plugins/sim_factory/CMakeLists.txt
+++ b/plugins/sim_factory/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(${plugin_lower}
   gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
   gz-transport${GZ_TRANSPORT_VER}::core
   gz-plugin${GZ_PLUGIN_VER}::core
+  gz_msgs_gen
 )
 
 install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})

--- a/plugins/sim_factory/SimFactory.cc
+++ b/plugins/sim_factory/SimFactory.cc
@@ -17,6 +17,7 @@
 
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_v.pb.h>
 #include <gz/msgs/stringmsg.pb.h>
 
 #include <gz/common/Util.hh>

--- a/plugins/sim_server/CMakeLists.txt
+++ b/plugins/sim_server/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(${plugin_lower}
   gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
   gz-transport${GZ_TRANSPORT_VER}::core
   gz-plugin${GZ_PLUGIN_VER}::core
+  gz_msgs_gen
 )
 
 install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})


### PR DESCRIPTION
Allows gz-launch to take advantage of the new message generation pipeline in https://github.com/gazebosim/gz-msgs/pull/339