### PR TITLE
Add package.xml, remove dependency on python3-yaml, and disable failing windows tests

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -20,6 +20,5 @@ libwebsockets-dev
 libxi-dev
 libxmu-dev
 libyaml-dev
-python3-yaml
 uuid-dev
 xvfb

--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -6,15 +6,6 @@ on:
 jobs:
   package-xml:
     runs-on: ubuntu-latest
-    name: package.xml and CMake versions match
+    name: Validate package.xml
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check versions
-        run: |
-          echo "Extract version numbers and compare"
-          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
-          echo "Version in package.xml: ${package_xml_version}"
-          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
-          echo "Version in CMake: ${cmake_version}"
-          [ $package_xml_version = $cmake_version ]
+      - uses: gazebo-tooling/action-gz-ci/validate_package_xml@jammy

--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -1,0 +1,20 @@
+name: Validate package.xml
+
+on:
+  pull_request:
+
+jobs:
+  package-xml:
+    runs-on: ubuntu-latest
+    name: package.xml and CMake versions match
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check versions
+        run: |
+          echo "Extract version numbers and compare"
+          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
+          echo "Version in package.xml: ${package_xml_version}"
+          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
+          echo "Version in CMake: ${cmake_version}"
+          [ $package_xml_version = $cmake_version ]

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>gz-launch7</name>
+  <version>7.0.0</version>
+  <description>Gazebo Launch : Run and manage programs and plugins</description>
+  <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
+  <license>Apache License 2.0</license>
+  <url type="website">https://github.com/gazebosim/gz-launch</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>binutils</depend>
+  <depend>gz-cmake3</depend>
+  <depend>gz-common5</depend>
+  <depend>gz-fuel-tools9</depend>
+  <depend>gz-gui8</depend>
+  <depend>gz-math7</depend>
+  <depend>gz-msgs10</depend>
+  <depend>gz-physics7</depend>
+  <depend>gz-plugin2</depend>
+  <depend>gz-rendering8</depend>
+  <depend>gz-sensors8</depend>
+  <depend>gz-sim8</depend>
+  <depend>gz-tools2</depend>
+  <depend>gz-transport13</depend>
+  <depend>libgflags-dev</depend>
+  <depend>libwebsockets-dev</depend>
+  <depend>libxi-dev</depend>
+  <depend>libxmu-dev</depend>
+  <depend>libyaml-dev</depend>
+  <depend>sdformat14</depend>
+  <depend>tinyxml2</depend>
+  <depend>uuid</depend>
+
+  <test_depend>xvfb</test_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>
+

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gz-launch7</name>
-  <version>7.0.0</version>
+  <version>7.1.0</version>
   <description>Gazebo Launch : Run and manage programs and plugins</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>

--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -137,7 +137,7 @@ TEST_F(ManagerTest, RunLs)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ManagerTest, RunEnvPre)
+TEST_F(ManagerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPre))
 {
   // Test that environment is applied regardless of order
   #ifndef _WIN32
@@ -175,7 +175,7 @@ TEST_F(ManagerTest, RunEnvPre)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ManagerTest, RunEnvPost)
+TEST_F(ManagerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPost))
 {
   // Test that environment is applied regardless of order
   #ifndef _WIN32

--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -112,7 +112,7 @@ TEST_F(ManagerTest, RunBadXml)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ManagerTest, RunLs)
+TEST_F(ManagerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunLs))
 {
   std::string cmd;
 


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add `package.xml` based on dependencies found in `.github/ci/packages`. 

I didn't find any use of python3-yaml, so I've removed it from `.github/ci/packages.apt`.

This is to test out using vendor packages to provide Gazebo packages to ROS users (see https://github.com/gazebo-tooling/release-tools/issues/1117). 
