### PR TITLE
Fix msvc warning

### DIFF
--- a/src/Manager.cc
+++ b/src/Manager.cc
@@ -381,7 +381,7 @@ ManagerPrivate::ManagerPrivate()
     const auto pid_seed = std::hash<std::thread::id>()(
         std::this_thread::get_id());
     std::seed_seq seed_value{time_seed, pid_seed};
-    std::vector<size_t> seeds(1);
+    std::vector<std::uint32_t> seeds(1);
     seed_value.generate(seeds.begin(), seeds.end());
     math::Rand::Seed(seeds[0]);
   }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
MSVC doesn't seem to like the use of `size_t` with `std::seed_seq::generate`. The `std::seed_seq::result_type` is `[std::uint_least32_t](https://en.cppreference.com/w/cpp/types/integer)` , and the [examples](https://en.cppreference.com/w/cpp/numeric/random/seed_seq/generate) all use `std::uint32_t`.

https://godbolt.org/z/db85bEf5z

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
