### PR TITLE
Fix bug where address of local variable was returned

### DIFF
--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -33,7 +33,7 @@ extern "C" char *gzVersion()
 extern "C" const char *configPath()
 {
   std::string configPath = gz::launch::getPluginInstallPath();
-  return configPath.c_str();
+  return strdup(configPath.c_str());
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

This patch returns a malloc'd copy instead.

This was introduced in #218. homebrew had a warning https://build.osrfoundation.org/job/gz_launch-ci-pr_any-homebrew-amd64/24/clang/, but our Linux CI was green: https://build.osrfoundation.org/job/gz_launch-ci-pr_any-focal-amd64/16/

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.