### PR TITLE
Use relative install paths for plugin shared libraries and gz-tools data

### DIFF
--- a/plugins/joy_to_twist/CMakeLists.txt
+++ b/plugins/joy_to_twist/CMakeLists.txt
@@ -11,4 +11,4 @@ target_link_libraries(${plugin}
     gz-transport${GZ_TRANSPORT_VER}::core
 )
 
-install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})
+install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})

--- a/plugins/joystick/CMakeLists.txt
+++ b/plugins/joystick/CMakeLists.txt
@@ -11,4 +11,4 @@ target_link_libraries(${plugin}
     gz-plugin${GZ_PLUGIN_VER}::core
 )
 
-install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})
+install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})

--- a/plugins/sim_factory/CMakeLists.txt
+++ b/plugins/sim_factory/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(${plugin_lower}
   gz-plugin${GZ_PLUGIN_VER}::core
 )
 
-install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})
+install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})

--- a/plugins/sim_gui/CMakeLists.txt
+++ b/plugins/sim_gui/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(${plugin_lower}
   gz-plugin${GZ_PLUGIN_VER}::core
 )
 
-install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})
+install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})

--- a/plugins/sim_server/CMakeLists.txt
+++ b/plugins/sim_server/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(${plugin_lower}
   gz-plugin${GZ_PLUGIN_VER}::core
 )
 
-install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})
+install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})

--- a/plugins/websocket_server/CMakeLists.txt
+++ b/plugins/websocket_server/CMakeLists.txt
@@ -25,5 +25,5 @@ if (websockets_FOUND)
       gz-transport${GZ_TRANSPORT_VER}::core
   )
 
-  install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_INSTALL_PATH})
+  install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})
 endif()

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -80,7 +80,7 @@ install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/launch${PROJECT_VERSION_MAJOR}.bash_completion.sh
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${GZ_TOOLS_VER}.completion.d)
+    ${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${GZ_TOOLS_VER}.completion.d)
 
 #===============================================================================
 # Generate the ruby script for internal testing.
@@ -151,7 +151,7 @@ configure_file(
 
 # Install the yaml configuration files in an unversioned location.
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml
-DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/)
+DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gz/)
 
 # Install the ruby command line library in an unversioned location.
 install(FILES ${cmd_script_generated} DESTINATION lib/ruby/gz)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes an error when building https://github.com/gazebo-release/gz_launch_vendor/ in the ROS buildfarm.

Similar to https://github.com/gazebosim/gz-tools/pull/137


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
