### PR TITLE
Disable cmdline tests on homebrew

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,11 @@ set (gtest_sources
   ign_TEST.cc
 )
 
+# Disable tests that need CLI on homebrew
+if (APPLE)
+  list(REMOVE_ITEM gtest_sources ign_TEST.cc)
+endif()
+
 # Create the library target.
 ign_create_core_library(SOURCES ${sources} CXX_STANDARD 17)
 

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -24,7 +24,7 @@
 #include <ignition/common/Filesystem.hh>
 #include "ignition/launch/test_config.hh"  // NOLINT(build/include)
 
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 static const std::string kIgnCommand(
     std::string("IGN_CONFIG_PATH=") + IGN_CONFIG_PATH + " " +

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -24,6 +24,8 @@
 #include <ignition/common/Filesystem.hh>
 #include "ignition/launch/test_config.hh"  // NOLINT(build/include)
 
+#include <ignition/utils/ExtraTestMacros.hh>
+
 static const std::string kIgnCommand(
     std::string("IGN_CONFIG_PATH=") + IGN_CONFIG_PATH + " " +
     std::string(BREW_RUBY) + std::string(IGN_PATH) + " launch ");
@@ -51,7 +53,7 @@ std::string customExecStr(std::string _cmd)
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, Ls)
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_MAC(Ls))
 {
   std::string cmd = kIgnCommand +
     std::string(PROJECT_SOURCE_PATH) + "/test/config/ls.ign";
@@ -65,7 +67,7 @@ TEST(CmdLine, Ls)
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, EchoSelf)
+TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_MAC(EchoSelf))
 {
   std::string filePath =
       std::string(PROJECT_SOURCE_PATH) + "/test/config/echo.ign";


### PR DESCRIPTION
## Summary
Disables cmdline tests that haven't passed on ign-launch2 job for homebrew, reference:
https://build.osrfoundation.org/job/gz_launch-ci-ign-launch2-homebrew-amd64/46/

I think that just adding the disable macro for the tests should be enough, but I'm following the same pattern used in https://github.com/gazebosim/gz-launch/pull/255 for consistency. 

cc: @Crola1702 

## Checklist
- [x] Signed all commits for DCO
- [x] Added (disables) tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
