### PR TITLE
Supress msvc dll exported interface warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PRIVATE
     ignition-common${IGN_COMMON_MAJOR_VER}::ignition-common${IGN_COMMON_MAJOR_VER}
     ignition-math${IGN_MATH_MAJOR_VER}::ignition-math${IGN_MATH_MAJOR_VER}
+    ignition-utils${IGN_UTILS_VER}::core
     ${BACKWARD_LIBRARIES}
 )
 

--- a/src/Manager.hh
+++ b/src/Manager.hh
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-// #include <ignition/common/SuppressWarning.hh>
+#include <ignition/utils/SuppressWarning.hh>
 
 #include <ignition/launch/Export.hh>
 
@@ -52,9 +52,9 @@ namespace ignition
       public: bool Stop();
 
       /// \brief Private data pointer.
-      // IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
+      IGN_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: std::unique_ptr<ManagerPrivate> dataPtr;
-      // IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
+      IGN_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -37,7 +37,7 @@ ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}
   LIB_DEPS ${EXTRA_TEST_LIB_DEPS})
 
 foreach(test ${test_list})
-  target_link_libraries(${test} ign)
+  target_link_libraries(${test} ign ignition-utils${IGN_UTILS_VER}::core)
 
   # Inform each test of its output directory so it knows where to call the
   # auxiliary files from. Using a generator expression here is useful for

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(${launch_executable}
   ign
   ignition-utils${IGN_UTILS_VER}::cli
   ignition-common${IGN_COMMON_MAJOR_VER}::ignition-common${IGN_COMMON_MAJOR_VER}
+  ignition-utils${IGN_UTILS_VER}::core
 )
 
 install(

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(ign PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ign PUBLIC
   ${PROJECT_LIBRARY_TARGET_NAME}
   ignition-common${IGN_COMMON_MAJOR_VER}::ignition-common${IGN_COMMON_MAJOR_VER}
+  ignition-utils${IGN_UTILS_VER}::core
 )
 
 set(launch_executable ign-launch)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT WIN32)
 
   ign_build_tests(TYPE INTEGRATION SOURCES ${tests} TEST_LIST test_targets)
   foreach(test ${test_targets})
+    target_link_libraries(${test} ignition-utils${IGN_UTILS_VER}::core)
     target_compile_definitions(${test} PRIVATE
         "bad_plugins_LIB=\"$<TARGET_FILE:bad_plugins>\"")
   endforeach()


### PR DESCRIPTION
## Summary
Suppresses a warning appearing in the CI job for ign-launch5. Reference build: https://build.osrfoundation.org/job/gz_launch-ign-launch5-win/49/

This fix was applied to gz-launch here: https://github.com/gazebosim/gz-launch/pull/199/files#diff-c3f9cb0a10e4084bda0abece3428e80d90754073fc083b78887bfbcf6276bb07

cc: @Crola1702 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.