### PR TITLE
Disable failing Manager_Test on windows

### DIFF
--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -112,7 +112,7 @@ TEST_F(ManagerTest, RunBadXml)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ManagerTest, RunLs)
+TEST_F(ManagerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunLs))
 {
   std::string cmd;
 
@@ -137,7 +137,7 @@ TEST_F(ManagerTest, RunLs)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ManagerTest, RunEnvPre)
+TEST_F(ManagerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPre))
 {
   // Test that environment is applied regardless of order
   #ifndef _WIN32
@@ -175,7 +175,7 @@ TEST_F(ManagerTest, RunEnvPre)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ManagerTest, RunEnvPost)
+TEST_F(ManagerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPost))
 {
   // Test that environment is applied regardless of order
   #ifndef _WIN32


### PR DESCRIPTION
## Summary
Disables a test failing on windows, follows the same approach applied to a newer branch here: https://github.com/gazebosim/gz-launch/pull/249

Reference build: 
https://build.osrfoundation.org/job/gz_launch-6-win/52/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
