### PR TITLE
Fix msvc loss of data warning

### DIFF
--- a/plugins/sim_factory/SimFactory.cc
+++ b/plugins/sim_factory/SimFactory.cc
@@ -152,7 +152,7 @@ bool SimFactory::Load(const tinyxml2::XMLElement *_elem)
 
   for (const auto &msg : this->worldFactoryMsgs)
   {
-    unsigned int timeout = 2000;
+    uint32_t timeout = 2000;
     msgs::Boolean rep;
     bool result;
 


### PR DESCRIPTION
## Summary
Attempt to fix the windows warning caused in the SimFactory code, reference:
https://build.osrfoundation.org/job/gz_launch-main-win/47/

It's complaining about an uint64 casted to protobuf::int32, so I think this PR should fix it. Don't fix it until checking win CI and validate if it actually fixes the problem.

cc: @Crola1702 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.