### PR TITLE
Fix libwebsocket shutdown behavior

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -613,9 +613,14 @@ void WebsocketServer::Run()
 
   while (this->run)
   {
-    // The second parameter is a timeout that is no longer used by
-    // libwebsockets.
-    lws_service(this->context, 0);
+    // The second parameter is used to control lws's event wait time.
+    // A -1 does not wait for an event, and 0 causes lws to wait
+    // for an event. When shutting down the websocket server, the
+    // wait time could be over 30 seconds if 0 is used.
+    //
+    // We are running lws in a separate thread with out our own
+    // condition variable. So, we will not use lws's event wait.
+    lws_service(this->context, -1);
 
     // Wait for (1/60) seconds or an event.
     std::unique_lock<std::mutex> lock(this->runMutex);


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #257

## Summary

Libwebsockets had it's own internal event wait. When shutting down the websocket server, the wait time could (and typically would) exceed 30 seconds. This PR bypasses libwebsocket's event wait time.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.