### PR TITLE
Find gz-gui without major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,7 @@ set(GZ_MATH_VER ${gz-math8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-gui
-gz_find_package(gz-gui10 REQUIRED)
-set(GZ_GUI_VER ${gz-gui10_VERSION_MAJOR})
+gz_find_package(gz-gui REQUIRED)
 gz_find_package (Qt5
   COMPONENTS
     Core

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   <depend>binutils</depend>
   <depend>gz-cmake4</depend>
   <depend>gz-common6</depend>
-  <depend>gz-gui10</depend>
+  <depend>gz-gui</depend>
   <depend>gz-math8</depend>
   <depend>gz-msgs11</depend>
   <depend>gz-plugin3</depend>

--- a/plugins/sim_gui/CMakeLists.txt
+++ b/plugins/sim_gui/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(${plugin_lower}
   gz-sim
   gz-sim::gui
   gz-sim::gz-sim
-  gz-gui${GZ_GUI_VER}::gz-gui${GZ_GUI_VER}
+  gz-gui::gz-gui
   gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
   gz-transport${GZ_TRANSPORT_VER}::core
   gz-plugin${GZ_PLUGIN_VER}::core


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1244, companion to gazebosim/gz-gui#670.

## Summary

The major version is removed from the cmake project name for gz-gui in gazebosim/gz-gui#670, so update the `find_package` and `target_link_libraries` calls accordingly.

## Test it

* Build gazebosim/gz-gui#670 and https://github.com/gazebosim/gz-sim/pull/2843 from source
* Compile this branch against them
* Confirm this builds successfully

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
