### PR TITLE
Remove find Qt in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,13 +76,17 @@ set(GZ_MATH_VER ${gz-math8_VERSION_MAJOR})
 #--------------------------------------
 # Find gz-gui
 gz_find_package(gz-gui REQUIRED)
-gz_find_package (Qt5
+
+set(QT_MAJOR_VERSION 6)
+set(QT_MINOR_VERSION 4)
+gz_find_package (Qt${QT_MAJOR_VERSION}
+  VERSION ${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}
   COMPONENTS
     Core
     Quick
     QuickControls2
   REQUIRED
-  PKGCONFIG "Qt5Core Qt5Quick Qt5QuickControls2")
+  PKGCONFIG "Qt${QT_MAJOR_VERSION}Core Qt${QT_MAJOR_VERSION}Quick Qt${QT_MAJOR_VERSION}QuickControls2")
 
 #--------------------------------------
 # Find gz-sim

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,17 +77,6 @@ set(GZ_MATH_VER ${gz-math8_VERSION_MAJOR})
 # Find gz-gui
 gz_find_package(gz-gui REQUIRED)
 
-set(QT_MAJOR_VERSION 6)
-set(QT_MINOR_VERSION 4)
-gz_find_package (Qt${QT_MAJOR_VERSION}
-  VERSION ${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}
-  COMPONENTS
-    Core
-    Quick
-    QuickControls2
-  REQUIRED
-  PKGCONFIG "Qt${QT_MAJOR_VERSION}Core Qt${QT_MAJOR_VERSION}Quick Qt${QT_MAJOR_VERSION}QuickControls2")
-
 #--------------------------------------
 # Find gz-sim
 gz_find_package(gz-sim REQUIRED PRIVATE COMPONENTS gui)


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Remove logic to find Qt in cmake. It should be sufficient to find gz-gui. 

I don't see any Qt includes in our source code or linking to Qt targets in cmake.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

